### PR TITLE
NumberInput - Fix the disappearing stepper buttons and hiding placeholder text

### DIFF
--- a/packages/ui-library/src/components/forms/number-input/index.test.ts
+++ b/packages/ui-library/src/components/forms/number-input/index.test.ts
@@ -35,7 +35,7 @@ describe('blr-number-input', () => {
     expect(type).to.be.equal('number');
   });
 
-  it('is is showing random placeholder', async () => {
+  it('is showing random placeholder', async () => {
     const randomString = getRandomString();
 
     const element = await fixture(
@@ -49,6 +49,22 @@ describe('blr-number-input', () => {
     const placeholder = input?.getAttribute('placeholder');
 
     expect(placeholder).to.be.equal(randomString);
+  });
+
+  it('is showing the stepper when unit is undefined and readonly is true', async () => {
+    const className = 'custom-stepper-button';
+
+    const element = await fixture(
+      BlrNumberInputRenderFunction({
+        ...sampleParams,
+        unit: undefined,
+      })
+    );
+
+    const button = querySelectorDeep('button', element.getRootNode() as HTMLElement);
+    const classNames = button?.getAttribute('class');
+
+    expect(classNames).to.include(className);
   });
 
   it('is shows adjacent caption components in caption group slot', async () => {

--- a/packages/ui-library/src/components/forms/number-input/index.ts
+++ b/packages/ui-library/src/components/forms/number-input/index.ts
@@ -83,7 +83,6 @@ export class BlrNumberInput extends LitElement {
       const padding = Math.max(digits - integerPart.length, 0);
       paddedInteger = '0'.repeat(padding) + integerPart;
     }
-    console.log(cur, fractions, digits, formattedNumber, integerPart, fractionPart, paddedInteger);
     return `${paddedInteger}${fractionPart ? `.${fractionPart}` : ''}`;
   }
 
@@ -226,7 +225,7 @@ export class BlrNumberInput extends LitElement {
           <input
             class="${inputClasses}"
             type="number"
-            .value=${!this.readonly
+            .value=${!this.readonly && this.currentValue != 0
               ? this.customFormat(this.currentValue || 0, this.fractionDigits || 0, this.totalDigits || 0)
               : nothing}
             step="${this.step || nothing}"

--- a/packages/ui-library/src/components/forms/number-input/index.ts
+++ b/packages/ui-library/src/components/forms/number-input/index.ts
@@ -83,7 +83,7 @@ export class BlrNumberInput extends LitElement {
       const padding = Math.max(digits - integerPart.length, 0);
       paddedInteger = '0'.repeat(padding) + integerPart;
     }
-
+    console.log(cur, fractions, digits, formattedNumber, integerPart, fractionPart, paddedInteger);
     return `${paddedInteger}${fractionPart ? `.${fractionPart}` : ''}`;
   }
 
@@ -237,12 +237,8 @@ export class BlrNumberInput extends LitElement {
             @change=${this.handleChange}
             placeholder=${this.placeholder || nothing}
           />
-          ${!this.readonly && this.unit
-            ? html`
-                <span class="${unitClasses}">${this.unit}</span>
-                ${this.renderMode()}
-              `
-            : nothing}
+          ${!this.readonly && this.unit ? html` <span class="${unitClasses}">${this.unit}</span> ` : nothing}
+          ${this.renderMode()}
         </div>
         ${this.hasHint || this.hasError
           ? BlrFormCaptionGroupRenderFunction({ size: this.size }, captionContent)


### PR DESCRIPTION
This MR fixes two issues:

- The disappearing stepper button upon two actions:
   - Setting the unit to `undefined`
   - Setting `readonly` to `true`

It extracts the stepper rendering method out of the conditional rendering of the unit text.
- Placeholder unable to appear because the default value is not undefined

It adds a condition to render the placeholder text for 0 value.