### PR TITLE
docs: update year in license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2023 B01LER Contributors
+Copyright (c) 2023-2024 B01LER
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the


### PR DESCRIPTION
- Updated year in license.md to 2023-2024
- Also fixed an error, where B01LER was not replacing the full placeholder