### PR TITLE
Code snipped fix

### DIFF
--- a/packages/ui-library/src/components/forms/radio/index.test.ts
+++ b/packages/ui-library/src/components/forms/radio/index.test.ts
@@ -7,8 +7,6 @@ import { fixture, expect } from '@open-wc/testing';
 import { querySelectorAllDeep, querySelectorDeep } from 'query-selector-shadow-dom';
 
 const sampleParams: BlrRadioType = {
-  checked: false,
-  disabled: false,
   name: 'Default Name',
   optionId: 'testId',
   label: 'harald',
@@ -17,6 +15,8 @@ const sampleParams: BlrRadioType = {
   hasHint: true,
   hasError: false,
   theme: 'Light',
+  checked: false,
+  disabled: false,
 };
 
 describe('blr-radio', () => {

--- a/packages/ui-library/src/components/forms/radio/index.test.ts
+++ b/packages/ui-library/src/components/forms/radio/index.test.ts
@@ -7,6 +7,8 @@ import { fixture, expect } from '@open-wc/testing';
 import { querySelectorAllDeep, querySelectorDeep } from 'query-selector-shadow-dom';
 
 const sampleParams: BlrRadioType = {
+  checked: false,
+  disabled: false,
   name: 'Default Name',
   optionId: 'testId',
   label: 'harald',
@@ -15,8 +17,6 @@ const sampleParams: BlrRadioType = {
   hasHint: true,
   hasError: false,
   theme: 'Light',
-  checked: false,
-  disabled: false,
 };
 
 describe('blr-radio', () => {

--- a/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
+++ b/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
@@ -41,6 +41,14 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
 
         values.push(value);
       }
+    } else if (typeof value === 'object') {
+      if (needsOpenTag) {
+        templateFragments.push(`<${tagName} .${key}=`);
+      } else {
+        templateFragments.push(` .${key}=`);
+      }
+
+      values.push(value);
     } else {
       if (needsOpenTag) {
         templateFragments.push(`<${tagName} ${key}=`);

--- a/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
+++ b/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
@@ -21,16 +21,12 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
       } else {
         templateFragments.push(` @${key}=`);
       }
-
-      values.push(value);
     } else if (key === 'classMap') {
       if (needsOpenTag) {
         templateFragments.push(`<${tagName} class=`);
       } else {
         templateFragments.push(` class=`);
       }
-
-      values.push(value);
     } else if (typeof value === 'boolean') {
       if (value === true) {
         if (needsOpenTag) {
@@ -38,8 +34,12 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
         } else {
           templateFragments.push(` ${key}=`);
         }
-
-        values.push(value);
+      } else {
+        if (needsOpenTag) {
+          templateFragments.push(`<${tagName} .${key}=`);
+        } else {
+          templateFragments.push(` .${key}=`);
+        }
       }
     } else if (typeof value === 'object') {
       if (needsOpenTag) {
@@ -47,17 +47,14 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
       } else {
         templateFragments.push(` .${key}=`);
       }
-
-      values.push(value);
     } else {
       if (needsOpenTag) {
         templateFragments.push(`<${tagName} ${key}=`);
       } else {
         templateFragments.push(` ${key}=`);
       }
-
-      values.push(value);
     }
+    values.push(value);
   });
 
   attrEntries.forEach(([key, value], index) => {

--- a/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
+++ b/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
@@ -12,9 +12,11 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
   const attrEntries = Object.entries(htmlAttributes || {});
 
   // we will get rid of the dots later on by defining bindings within the component property decorator
-  propEntries.forEach(([key, value], index) => {
+  propEntries.forEach(([key, value]) => {
+    const needsOpenTag = templateFragments.length === 0;
+
     if (typeof value === 'function') {
-      if (index === 0) {
+      if (needsOpenTag) {
         templateFragments.push(`<${tagName} @${key}=`);
       } else {
         templateFragments.push(` @${key}=`);
@@ -22,7 +24,7 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
 
       values.push(value);
     } else if (key === 'classMap') {
-      if (index === 0) {
+      if (needsOpenTag) {
         templateFragments.push(`<${tagName} class=`);
       } else {
         templateFragments.push(` class=`);
@@ -31,7 +33,7 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
       values.push(value);
     } else if (typeof value === 'boolean') {
       if (value === true) {
-        if (index === 0) {
+        if (needsOpenTag) {
           templateFragments.push(`<${tagName} ${key}=`);
         } else {
           templateFragments.push(` ${key}=`);
@@ -40,7 +42,7 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
         values.push(value);
       }
     } else {
-      if (index === 0) {
+      if (needsOpenTag) {
         templateFragments.push(`<${tagName} ${key}=`);
       } else {
         templateFragments.push(` ${key}=`);

--- a/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
+++ b/packages/ui-library/src/utils/typesafe-generic-component-renderer.ts
@@ -19,21 +19,35 @@ export const genericBlrComponentRenderer = <ComponentType extends { [s: string]:
       } else {
         templateFragments.push(` @${key}=`);
       }
+
+      values.push(value);
     } else if (key === 'classMap') {
       if (index === 0) {
         templateFragments.push(`<${tagName} class=`);
       } else {
         templateFragments.push(` class=`);
       }
+
+      values.push(value);
+    } else if (typeof value === 'boolean') {
+      if (value === true) {
+        if (index === 0) {
+          templateFragments.push(`<${tagName} ${key}=`);
+        } else {
+          templateFragments.push(` ${key}=`);
+        }
+
+        values.push(value);
+      }
     } else {
       if (index === 0) {
-        templateFragments.push(`<${tagName} .${key}=`);
+        templateFragments.push(`<${tagName} ${key}=`);
       } else {
-        templateFragments.push(` .${key}=`);
+        templateFragments.push(` ${key}=`);
       }
-    }
 
-    values.push(value);
+      values.push(value);
+    }
   });
 
   attrEntries.forEach(([key, value], index) => {


### PR DESCRIPTION
this pr changes the render function to only use dots in two cases:

if the value is an object/array or if the value is a boolean false. 
In both cases, you will not see key/value in storybooks code preview.

Since we want to move away from arrays anyway, this is actually not a problem for us