### PR TITLE
fix(all): use new name of lit-analyzer extension in vs code recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",
-    "runem.lit-analyzer"
+    "runem.lit-plugin"
   ]
 }


### PR DESCRIPTION
I just noticed this while setting up vs code for work on the project when I was wondering which of the plugins I should install 🙂 

The name seems to have changed, the [lit-analyzer repo](https://github.com/runem/lit-analyzer) also links to the `runem.lit-plugin` extension (`runem.lit-analyzer` doesn't exist)