### PR TITLE
fix 774 number input accessibility

### DIFF
--- a/packages/ui-library/src/components/form-label/index.stories.ts
+++ b/packages/ui-library/src/components/form-label/index.stories.ts
@@ -4,6 +4,8 @@ import { FormSizes, LabelVariants } from '../../globals/constants';
 import { BlrFormLabelType } from './index';
 import { BlrFormLabelRenderFunction } from './renderFunction';
 import { html } from 'lit-html';
+import { LitElement } from 'lit';
+import { genericBlrComponentRenderer } from '../../utils/typesafe-generic-component-renderer';
 import '../../index';
 
 const sharedStyles = html`
@@ -109,7 +111,22 @@ export default {
   },
 };
 
-export const BlrFormLabel = (params: BlrFormLabelType) => BlrFormLabelRenderFunction(params);
+// The label is not creating a shadow root itself, but errors if it is outside
+// of one. Thus, we're creating a helper component for the stories, that wraps it.
+class WrappedBlrLabel extends LitElement {
+  labelProps: BlrFormLabelType;
+
+  protected render() {
+    return BlrFormLabelRenderFunction(this.labelProps);
+  }
+}
+
+customElements.define('label-story', WrappedBlrLabel);
+
+const WrappedBlrFormLabelRenderFunction = (params: BlrFormLabelType) =>
+  genericBlrComponentRenderer('label-story', { labelProps: params });
+
+export const BlrFormLabel = (params: BlrFormLabelType) => WrappedBlrFormLabelRenderFunction(params);
 BlrFormLabel.storyName = 'Form Label';
 
 const defaultParams: BlrFormLabelType = {
@@ -130,7 +147,7 @@ BlrFormLabel.args = defaultParams;
 export const SizeVariant = () => {
   return html`${sharedStyles}
     <div class="stories-form-label">
-      ${BlrFormLabelRenderFunction({
+      ${WrappedBlrFormLabelRenderFunction({
         ...defaultParams,
         labelSize: 'sm',
         labelText: 'Form label SM',
@@ -138,7 +155,7 @@ export const SizeVariant = () => {
       })}
     </div>
     <div class="stories-form-label">
-      ${BlrFormLabelRenderFunction({
+      ${WrappedBlrFormLabelRenderFunction({
         ...defaultParams,
         labelSize: 'md',
         labelText: 'Form label MD',
@@ -146,7 +163,7 @@ export const SizeVariant = () => {
       })}
     </div>
     <div class="stories-form-label">
-      ${BlrFormLabelRenderFunction({
+      ${WrappedBlrFormLabelRenderFunction({
         ...defaultParams,
         labelSize: 'lg',
         labelText: 'Form label LG',
@@ -163,19 +180,19 @@ SizeVariant.story = { name: ' ' };
  */
 export const LabelAppendix = () => {
   return html`
-    ${BlrFormLabelRenderFunction({
+    ${WrappedBlrFormLabelRenderFunction({
       ...defaultParams,
       labelSize: 'lg',
       labelText: 'Form label',
       labelAppendix: '(required)',
     })}
-    ${BlrFormLabelRenderFunction({
+    ${WrappedBlrFormLabelRenderFunction({
       ...defaultParams,
       labelSize: 'lg',
       labelText: 'Form label',
       labelAppendix: '(optional)',
     })}
-    ${BlrFormLabelRenderFunction({
+    ${WrappedBlrFormLabelRenderFunction({
       ...defaultParams,
       labelSize: 'lg',
       labelText: 'Form label',
@@ -192,7 +209,7 @@ LabelAppendix.story = { name: ' ' };
  * The Form Label component can be set to have an error.
  */
 export const HasError = () => {
-  return html` ${BlrFormLabelRenderFunction({
+  return html` ${WrappedBlrFormLabelRenderFunction({
     ...defaultParams,
     labelText: 'Error',
     labelAppendix: '(with Appendix)',

--- a/packages/ui-library/src/components/form-label/index.test.ts
+++ b/packages/ui-library/src/components/form-label/index.test.ts
@@ -1,10 +1,11 @@
 import '@boiler/ui-library/dist/';
 
 import { BlrFormLabelRenderFunction } from './renderFunction';
-import type { BlrFormLabelType } from '.';
-
+import type { BlrFormLabel, BlrFormLabelType } from '.';
 import { fixture, expect } from '@open-wc/testing';
 import { querySelectorDeep } from 'query-selector-shadow-dom';
+import { genericBlrComponentRenderer } from '../../utils/typesafe-generic-component-renderer';
+import { LitElement } from 'lit';
 
 const sampleParams: BlrFormLabelType = {
   theme: 'Light',
@@ -14,16 +15,39 @@ const sampleParams: BlrFormLabelType = {
   variant: 'label',
 };
 
+// The label is not creating a shadow root itself, but errors if it is outside
+// of one. Thus, we're creating a helper component for the stories, that wraps it.
+class WrappedBlrLabel extends LitElement {
+  labelProps: BlrFormLabelType;
+
+  protected render() {
+    return BlrFormLabelRenderFunction(this.labelProps);
+  }
+}
+
+customElements.define('label-test', WrappedBlrLabel);
+
+const WrappedBlrFormLabelRenderFunction = (params: BlrFormLabelType) =>
+  genericBlrComponentRenderer('label-test', { labelProps: params });
+
 describe('blr-form-label', () => {
   it('renders a <label> element inside Shadow DOM', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction(sampleParams));
     const blrLabel = querySelectorDeep('label.blr-form-label', element.getRootNode() as HTMLElement);
     expect(blrLabel).to.exist;
   });
 
+  it('errors when rendering a <label> element directly in the light DOM', async () => {
+    const element: BlrFormLabel = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const blrLabel = querySelectorDeep('label.blr-form-label', element.getRootNode() as HTMLElement);
+
+    expect(blrLabel).not.to.exist;
+    expect(element.error).to.exist;
+  });
+
   it('renders a <label> with new value', async () => {
     const element = await fixture(
-      BlrFormLabelRenderFunction({
+      WrappedBlrFormLabelRenderFunction({
         ...sampleParams,
         labelText: 'New label',
         labelAppendix: '',
@@ -36,14 +60,14 @@ describe('blr-form-label', () => {
   });
 
   it('renders a appendix element inside <label>', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction(sampleParams));
     const blrLabel = querySelectorDeep('label.blr-form-label', element.getRootNode() as HTMLElement);
     const eleAppendix = querySelectorDeep('span.blr-form-label-appendix', blrLabel?.getRootNode() as HTMLElement);
     expect(eleAppendix).to.exist;
   });
 
   it('renders a appendix element with no specific value', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction(sampleParams));
     const blrLabel = querySelectorDeep('label.blr-form-label', element.getRootNode() as HTMLElement);
     const eleAppendix = querySelectorDeep('span.blr-form-label-appendix', blrLabel?.getRootNode() as HTMLElement);
 
@@ -53,7 +77,7 @@ describe('blr-form-label', () => {
 
   it('renders a appendix element should contain specific value', async () => {
     const element = await fixture(
-      BlrFormLabelRenderFunction({
+      WrappedBlrFormLabelRenderFunction({
         ...sampleParams,
         labelText: 'New label',
         labelAppendix: '',
@@ -67,7 +91,7 @@ describe('blr-form-label', () => {
   });
 
   it('renders a <label> element with for attribute', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction(sampleParams));
     const blrLabel = querySelectorDeep('label.blr-form-label', element.getRootNode() as HTMLElement);
     const forValue = blrLabel?.getAttribute('for');
 
@@ -76,7 +100,7 @@ describe('blr-form-label', () => {
 
   it('renders a <label> element as error component', async () => {
     const element = await fixture(
-      BlrFormLabelRenderFunction({
+      WrappedBlrFormLabelRenderFunction({
         ...sampleParams,
         variant: 'error',
       })
@@ -87,7 +111,7 @@ describe('blr-form-label', () => {
   });
 
   it('has a size md by default', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction(sampleParams));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction(sampleParams));
 
     const label = querySelectorDeep('label', element.getRootNode() as HTMLElement);
     const className = label?.className;
@@ -96,7 +120,7 @@ describe('blr-form-label', () => {
   });
 
   it('has a size sm when "size" is set to "sm" ', async () => {
-    const element = await fixture(BlrFormLabelRenderFunction({ ...sampleParams, labelSize: 'sm' }));
+    const element = await fixture(WrappedBlrFormLabelRenderFunction({ ...sampleParams, labelSize: 'sm' }));
 
     const label = querySelectorDeep('label', element.getRootNode() as HTMLElement);
     const className = label?.className;

--- a/packages/ui-library/src/components/form-label/index.ts
+++ b/packages/ui-library/src/components/form-label/index.ts
@@ -16,8 +16,33 @@ export class BlrFormLabel extends LitElement {
   @property() theme: ThemeType = 'Light';
   @property() variant: LabelVariantType = 'label';
 
+  private _error: Error | null = null;
+
+  createRenderRoot() {
+    const isInShadowRoot = this.getRootNode() instanceof ShadowRoot;
+    if (!isInShadowRoot) {
+      // BlrFormLabel is not supposed to be rendered outside of another
+      // component's shadow-dom, as it is unencapsulated!
+      this._error = new Error(
+        "BlrFormLabel is not supposed to be rendered outside of another component's shadow-dom, as it is unencapsulated!"
+      );
+    }
+
+    // Important: Using this trick, we're opting out of creating a shadow root!
+    //
+    // This makes this element _not_ encapsulated from its parent, which is
+    // necessary for the accessibility tree to see the relation between the
+    // label and a form input.
+    return this;
+  }
+
+  /** Readonly error */
+  get error(): Error | null {
+    return this._error;
+  }
+
   protected render() {
-    if (this.labelSize) {
+    if (this.labelSize && !this._error) {
       const dynamicStyles = this.theme === 'Light' ? [formLight] : [formDark];
 
       const labelClasses = classMap({
@@ -46,4 +71,4 @@ if (!customElements.get(TAG_NAME)) {
   customElements.define(TAG_NAME, BlrFormLabel);
 }
 
-export type BlrFormLabelType = Omit<BlrFormLabel, keyof LitElement>;
+export type BlrFormLabelType = Omit<BlrFormLabel, keyof LitElement | 'createRenderRoot' | 'error'>;

--- a/packages/ui-library/src/components/number-input/index.css.ts
+++ b/packages/ui-library/src/components/number-input/index.css.ts
@@ -78,6 +78,11 @@ export const { tokenizedLight: wrapperLight, tokenizedDark: wrapperDark } = rend
 
     input {
       all: initial;
+      color: ${UserInput.Default.Rest};
+
+      &::placeholder {
+        color: ${Placeholder.Default.Rest};
+      }
     }
 
     & > * {

--- a/packages/ui-library/src/components/number-input/index.stories.ts
+++ b/packages/ui-library/src/components/number-input/index.stories.ts
@@ -379,12 +379,12 @@ export const NumberInput = (params: BlrNumberInputType) => BlrNumberInputRenderF
  *  ### Size Variant
  * The Number Input component comes in 3 sizes: SM, MD and LG.
  */
-export const SizeVariant = () => {
+export const SizeVariant = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         labelAppendix: undefined,
         size: 'sm',
         label: 'Number input SM',
@@ -394,7 +394,7 @@ export const SizeVariant = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         labelAppendix: undefined,
         size: 'md',
         label: 'Number input MD',
@@ -404,7 +404,7 @@ export const SizeVariant = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         labelAppendix: undefined,
         size: 'lg',
         label: 'Number input LG',
@@ -421,11 +421,11 @@ SizeVariant.story = { name: ' ' };
 The Number Input component has 3 stepper variants: vertical, horizontal and split.
  */
 
-export const StepperVariant = () =>
+export const StepperVariant = (params: BlrNumberInputType) =>
   html`
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         stepperVariant: 'vertical',
         label: 'Vertical',
         labelAppendix: undefined,
@@ -436,7 +436,7 @@ export const StepperVariant = () =>
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         stepperVariant: 'horizontal',
         label: 'Horizontal',
         labelAppendix: undefined,
@@ -447,7 +447,7 @@ export const StepperVariant = () =>
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         stepperVariant: 'split',
         label: 'Split',
         labelAppendix: undefined,
@@ -463,12 +463,12 @@ export const StepperVariant = () =>
  ### Placeholder
  * The Number Input component can display a placeholder text. This is recommended to improve usability.
  */
-export const Placeholder = () => {
+export const Placeholder = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         size: 'md',
         label: 'With placeholder',
         labelAppendix: undefined,
@@ -478,7 +478,7 @@ export const Placeholder = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         size: 'md',
         label: 'Without placeholder',
         labelAppendix: undefined,
@@ -495,12 +495,12 @@ Placeholder.story = { name: ' ' };
 /**
  * The Number Input component can display a unit either as a prefix or a suffix.
  */
-export const HasUnit = () => {
+export const HasUnit = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'No unit',
         unit: undefined,
         labelAppendix: undefined,
@@ -509,7 +509,7 @@ export const HasUnit = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Unit prefix',
         prependUnit: true,
         unit: 'kg',
@@ -519,10 +519,9 @@ export const HasUnit = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Unit suffix',
         prependUnit: false,
-        value: undefined,
         unit: 'kg',
         labelAppendix: undefined,
         numberInputId: 'test-kg-suff',
@@ -537,12 +536,12 @@ export const HasUnit = () => {
  * ### Disabled
 The Number Input component in the disabled state can not be interacted with. This means it can not receive focus or be selected.
 */
-export const Disabled = () => {
+export const Disabled = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Disabled',
         disabled: true,
         labelAppendix: undefined,
@@ -557,12 +556,12 @@ Disabled.story = { name: ' ' };
 /**
  * The Number Input component in the readonly state can not be interacted with, but it can still be selected and receive focus.
  */
-export const Readonly = () => {
+export const Readonly = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Readonly',
         readonly: true,
         labelAppendix: undefined,
@@ -579,12 +578,12 @@ export const Readonly = () => {
  * ### Required
  * The Number Input component can be set as required. If set as required, an error should be thrown, when the Number Input component was not filled, before it was submitted. It is recommended to indicate in the label appendix, whether a component is required or not. For more information on the label and label appendix have a look at the [Form Label](#form-label) component in the dependencies section below.
  */
-export const Required = () => {
+export const Required = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         required: true,
         labelAppendix: '(required)',
         numberInputId: 'test-req',
@@ -598,12 +597,12 @@ Required.story = { name: ' ' };
 /**
  * The Number Input component can be set to have an error. An error can be displayed after submitting a wrong value, after leaving/deselecting the Number Input or in case the Number Input was set as required and has not been filled before submitting. For more information on the error message have a look at the [Form Caption Group](#form-caption-group) in the dependencies section below.
  */
-export const HasError = () => {
+export const HasError = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Error',
         hasError: true,
         labelAppendix: undefined,
@@ -618,12 +617,12 @@ export const HasError = () => {
  * ### Icon Button
  * The Number Input component makes use of the Icon Button component for increasing or decreasing the value. For more information have a look at the [Icon Button](?path=/docs/design-system-web-components-actions-buttons-icon-button--docs) component.
  */
-export const IconButton = () => {
+export const IconButton = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         unit: 'kg',
         labelAppendix: undefined,
         stepperVariant: 'split',
@@ -638,12 +637,12 @@ IconButton.story = { name: ' ' };
 /**
  * The Number Input component can display an optional Form Label component, consisting of a label and a label appendix. For more information have a look at the internal [Form Label](?path=/docs/design-system-web-components-internal-components-formlabel--docs) component.
  */
-export const FormLabel = () => {
+export const FormLabel = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         placeholder: '',
         label: 'With label',
         labelAppendix: '(with appendix)',
@@ -653,7 +652,7 @@ export const FormLabel = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         placeholder: 'Without label',
         label: ' ',
         labelAppendix: '',
@@ -668,12 +667,12 @@ export const FormLabel = () => {
 /**
  * The Number Input component can display an optional hint message and error message with icons. Both captions can be combined. For more information have a look at the internal [Form Caption Group](?path=/docs/design-system-web-components-internal-components-formcaptiongroup--docs) component.
  */
-export const FormCaptionGroup = () => {
+export const FormCaptionGroup = (params: BlrNumberInputType) => {
   return html`
     ${sharedStyles}
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         hasHint: true,
         label: 'Hint message',
         hintIcon: 'blrInfo',
@@ -683,7 +682,7 @@ export const FormCaptionGroup = () => {
     </div>
     <div class="wrapper">
       ${BlrNumberInputRenderFunction({
-        ...defaultParams,
+        ...params,
         label: 'Hint and error message',
         labelAppendix: undefined,
         hasError: true,

--- a/packages/ui-library/src/components/number-input/index.stories.ts
+++ b/packages/ui-library/src/components/number-input/index.stories.ts
@@ -42,6 +42,8 @@ const defaultParams: BlrNumberInputType = {
   errorMessage: '',
   errorIcon: undefined,
   numberInputId: 'test-id',
+  stepIncreaseAriaLabel: '+',
+  stepDecreaseAriaLabel: '\u2212',
 };
 
 export default {
@@ -268,16 +270,6 @@ export default {
       if: { arg: 'hasError', eq: true },
     },
     //Technical attributes
-    ariaLabel: {
-      name: 'ariaLabel',
-      description:
-        'Provides additional information about the elements purpose and functionality to assistive technologies, such as screen readers.',
-      table: {
-        category: 'Accessibility',
-      },
-      control: { type: 'text', defaultValue: 'Default value' },
-    },
-
     numberInputId: {
       name: 'numberInputId',
       description: 'Unique identifier for this component.',
@@ -329,6 +321,24 @@ export default {
         category: 'Events',
       },
     },
+    // Accessibility attributes
+    stepIncreaseAriaLabel: {
+      name: 'stepIncreaseAriaLabel',
+      description: 'Labels the "up" or increase stepper button to assistive technologies, such as screen readers.',
+      table: {
+        category: 'Accessibility',
+      },
+      control: { type: 'text', defaultValue: '+' },
+    },
+    stepDecreaseAriaLabel: {
+      name: 'stepDecreaseAriaLabel',
+      description:
+        'Labels the "down" or decrease stepper button to assistive technologies, such as screen readers.\nNote that the default value is not a hyphen (-) but the minus sign \\u2212 (\u2212).',
+      table: {
+        category: 'Accessibility',
+      },
+      control: { type: 'text', defaultValue: '\u2212' },
+    },
   },
   parameters: {
     design: {
@@ -379,6 +389,7 @@ export const SizeVariant = () => {
         size: 'sm',
         label: 'Number input SM',
         value: undefined,
+        numberInputId: 'test-sm',
       })}
     </div>
     <div class="wrapper">
@@ -388,6 +399,7 @@ export const SizeVariant = () => {
         size: 'md',
         label: 'Number input MD',
         value: undefined,
+        numberInputId: 'test-md',
       })}
     </div>
     <div class="wrapper">
@@ -397,6 +409,7 @@ export const SizeVariant = () => {
         size: 'lg',
         label: 'Number input LG',
         value: undefined,
+        numberInputId: 'test-lg',
       })}
     </div>
   `;
@@ -418,6 +431,7 @@ export const StepperVariant = () =>
         labelAppendix: undefined,
         unit: 'kg',
         value: undefined,
+        numberInputId: 'test-vert',
       })}
     </div>
     <div class="wrapper">
@@ -428,6 +442,7 @@ export const StepperVariant = () =>
         labelAppendix: undefined,
         unit: 'kg',
         value: undefined,
+        numberInputId: 'test-hor',
       })}
     </div>
     <div class="wrapper">
@@ -438,6 +453,7 @@ export const StepperVariant = () =>
         labelAppendix: undefined,
         unit: 'kg',
         value: undefined,
+        numberInputId: 'test-split',
       })}
     </div>
   `;
@@ -457,6 +473,7 @@ export const Placeholder = () => {
         label: 'With placeholder',
         labelAppendix: undefined,
         value: undefined,
+        numberInputId: 'test-with',
       })}
     </div>
     <div class="wrapper">
@@ -467,6 +484,7 @@ export const Placeholder = () => {
         labelAppendix: undefined,
         placeholder: '',
         value: undefined,
+        numberInputId: 'test-without',
       })}
     </div>
   `;
@@ -486,6 +504,7 @@ export const HasUnit = () => {
         label: 'No unit',
         unit: undefined,
         labelAppendix: undefined,
+        numberInputId: 'test-no',
       })}
     </div>
     <div class="wrapper">
@@ -495,6 +514,7 @@ export const HasUnit = () => {
         prependUnit: true,
         unit: 'kg',
         labelAppendix: undefined,
+        numberInputId: 'test-kg-pre',
       })}
     </div>
     <div class="wrapper">
@@ -505,6 +525,7 @@ export const HasUnit = () => {
         value: undefined,
         unit: 'kg',
         labelAppendix: undefined,
+        numberInputId: 'test-kg-suff',
       })}
     </div>
   `;
@@ -525,6 +546,7 @@ export const Disabled = () => {
         label: 'Disabled',
         disabled: true,
         labelAppendix: undefined,
+        numberInputId: 'test-disabled',
       })}
     </div>
   `;
@@ -546,6 +568,7 @@ export const Readonly = () => {
         labelAppendix: undefined,
         decimals: 1,
         value: 20.2,
+        numberInputId: 'test-readonly',
       })}
     </div>
   `;
@@ -564,6 +587,7 @@ export const Required = () => {
         ...defaultParams,
         required: true,
         labelAppendix: '(required)',
+        numberInputId: 'test-req',
       })}
     </div>
   `;
@@ -583,6 +607,7 @@ export const HasError = () => {
         label: 'Error',
         hasError: true,
         labelAppendix: undefined,
+        numberInputId: 'test-error',
       })}
     </div>
   `;
@@ -602,6 +627,7 @@ export const IconButton = () => {
         unit: 'kg',
         labelAppendix: undefined,
         stepperVariant: 'split',
+        numberInputId: 'test-icon',
       })}
     </div>
   `;
@@ -622,6 +648,7 @@ export const FormLabel = () => {
         label: 'With label',
         labelAppendix: '(with appendix)',
         value: undefined,
+        numberInputId: 'test-label',
       })}
     </div>
     <div class="wrapper">
@@ -632,6 +659,7 @@ export const FormLabel = () => {
         labelAppendix: '',
         hasHint: false,
         value: undefined,
+        numberInputId: 'test-no-label',
       })}
     </div>
   `;
@@ -650,6 +678,7 @@ export const FormCaptionGroup = () => {
         label: 'Hint message',
         hintIcon: 'blrInfo',
         labelAppendix: '',
+        numberInputId: 'test-hint',
       })}
     </div>
     <div class="wrapper">
@@ -661,6 +690,7 @@ export const FormCaptionGroup = () => {
         errorMessage: "OMG it's an error",
         hasHint: true,
         errorIcon: 'blrErrorFilled',
+        numberInputId: 'test-hint-error',
       })}
     </div>
   `;

--- a/packages/ui-library/src/components/number-input/index.ts
+++ b/packages/ui-library/src/components/number-input/index.ts
@@ -43,6 +43,8 @@ export class BlrNumberInput extends LitElement {
   @property() leadingZeros?: number;
   @property() decimals?: number;
   @property() prependUnit?: boolean;
+  @property() stepIncreaseAriaLabel?: string = '+';
+  @property() stepDecreaseAriaLabel?: string = '\u2212'; // minus-sign (not minus-hyphen)
 
   @property() theme: ThemeType = 'Light';
 
@@ -82,10 +84,13 @@ export class BlrNumberInput extends LitElement {
     return `${paddedInteger}${fractionPart ? `.${fractionPart}` : ''}`;
   }
 
-  protected getButtonTemplate(icon: SizelessIconType, onClick: () => void): TemplateResult<1> {
+  protected getStepperButtonTemplate(direction: 'increase' | 'decrease', icon: SizelessIconType): TemplateResult<1> {
     if (!this.size) {
       return html``;
     }
+
+    const ariaLabel = direction === 'increase' ? this.stepIncreaseAriaLabel! : this.stepDecreaseAriaLabel!;
+    const onClick = direction === 'increase' ? this.stepperUp : this.stepperDown;
 
     const iconSizeVariant = getComponentConfigToken([
       'SizeVariant',
@@ -106,7 +111,13 @@ export class BlrNumberInput extends LitElement {
     });
 
     const button = html`
-      <button ?disabled="${this.disabled}" class="${buttonClass}" @click=${onClick}>
+      <button
+        aria-label=${ariaLabel}
+        aria-controls=${this.numberInputId}
+        ?disabled="${this.disabled}"
+        class="${buttonClass}"
+        @click=${onClick}
+      >
         ${BlrIconRenderFunction(
           {
             classMap: iconClasses,
@@ -126,30 +137,31 @@ export class BlrNumberInput extends LitElement {
     switch (this.stepperVariant) {
       case 'split': {
         return html`
-          ${this.getButtonTemplate('blrMinus', this.stepperDown)} ${this.getButtonTemplate('blrPlus', this.stepperUp)}
+          ${this.getStepperButtonTemplate('decrease', 'blrMinus')}
+          ${this.getStepperButtonTemplate('increase', 'blrPlus')}
         `;
       }
       case 'horizontal': {
         return html`
           <div class="stepper-combo horizontal  ${this.size}">
-            ${this.getButtonTemplate('blrMinus', this.stepperDown)}
+            ${this.getStepperButtonTemplate('decrease', 'blrMinus')}
             ${BlrDividerRenderFunction({
               direction: 'vertical',
               theme: this.theme,
             })}
-            ${this.getButtonTemplate('blrPlus', this.stepperUp)}
+            ${this.getStepperButtonTemplate('increase', 'blrPlus')}
           </div>
         `;
       }
       case 'vertical': {
         return html`
           <div class="stepper-combo vertical  ${this.size}">
-            ${this.getButtonTemplate('blrChevronUp', this.stepperUp)}
+            ${this.getStepperButtonTemplate('increase', 'blrChevronUp')}
             ${BlrDividerRenderFunction({
               direction: 'horizontal',
               theme: this.theme,
             })}
-            ${this.getButtonTemplate('blrChevronDown', this.stepperDown)}
+            ${this.getStepperButtonTemplate('decrease', 'blrChevronDown')}
           </div>
         `;
       }
@@ -245,6 +257,7 @@ export class BlrNumberInput extends LitElement {
           <div class="${wrapperClasses}">
             <div class="${inputAndUnitContainer}">
               <input
+                id="${this.numberInputId}"
                 class="${inputClasses}"
                 type="number"
                 .value=${this.currentValue != 0


### PR DESCRIPTION
Issue: #774 

The changes to the label were necessary to preserve the releation between the input and its label, both for the accessibility tree, and for standard browser behaviour (e.g. click on label focuses input)