### PR TITLE
fix(icons): auto generated icon type needs const array

### DIFF
--- a/packages/icons/icons-optimized/index.ts
+++ b/packages/icons/icons-optimized/index.ts
@@ -1500,7 +1500,7 @@ export const PureIconKeys = [
   'blrVideoCamera',
   'blrVideo',
   'blrWiFi',
-];
+] as const;
 
 export const IconMapping = {
   blr360Lg,

--- a/packages/icons/scripts/index.mjs
+++ b/packages/icons/scripts/index.mjs
@@ -46,7 +46,7 @@ fs.readdir(iconDir, (err, files) => {
 
     export const PureIconKeys = [
       ${pureKeys.join(',\n')}
-    ];
+    ] as const;
 
     export const IconMapping = { ${iconNames.map((icon) => icon).join(',\n')} };
     export type IconType = keyof typeof IconMapping;


### PR DESCRIPTION
This changes the `SizelessIcon` type from `string` to the union of valid icon names.